### PR TITLE
GC-56: to_collision_dict anchors at the shape's centre, matching the renderer

### DIFF
--- a/core/block.gd
+++ b/core/block.gd
@@ -289,24 +289,31 @@ func to_collision_dict() -> Dictionary:
 	var half_z: float
 	var height: float
 
+	# GC-56: the authored position is the shape's vertical CENTRE — every Godot
+	# primitive the builder creates is centered on its node origin, and the
+	# content was authored against that rendering. `height` is therefore the
+	# position plus HALF the vertical extent. The old `+ full size.y` convention
+	# inflated every exported box upward by half its height, which told the
+	# server that players standing on rendered surfaces were metres inside solid
+	# terrain (SV-28). Keep in lockstep with collision-math.ts localExtents.
 	match collision_shape:
 		BlockCategories.SHAPE_BOX, BlockCategories.SHAPE_RAMP:
 			half_x = collision_size.x * scale_factor / 2.0
 			half_z = collision_size.z * scale_factor / 2.0
-			height = position.y + collision_offset.y + collision_size.y * scale_factor
+			height = position.y + collision_offset.y + collision_size.y * scale_factor / 2.0
 		BlockCategories.SHAPE_CYLINDER, BlockCategories.SHAPE_CAPSULE, BlockCategories.SHAPE_SPHERE:
 			half_x = collision_size.x * scale_factor  # radius
 			half_z = collision_size.x * scale_factor
-			height = position.y + collision_offset.y + collision_size.y * scale_factor
+			height = position.y + collision_offset.y + collision_size.y * scale_factor / 2.0
 		BlockCategories.SHAPE_CONE, BlockCategories.SHAPE_ROCK:
 			half_x = collision_size.x * scale_factor  # radius
 			half_z = collision_size.x * scale_factor
-			height = position.y + collision_offset.y + collision_size.y * scale_factor
+			height = position.y + collision_offset.y + collision_size.y * scale_factor / 2.0
 		BlockCategories.SHAPE_TORUS, BlockCategories.SHAPE_ARCH:
 			half_x = collision_size.y * scale_factor  # outer_radius
 			half_z = collision_size.y * scale_factor
 			var ring_r := (collision_size.y - collision_size.x) * scale_factor
-			height = position.y + collision_offset.y + ring_r * 2.0
+			height = position.y + collision_offset.y + ring_r
 		_:
 			return {}
 


### PR DESCRIPTION
The authored block position is the shape's vertical **CENTRE**, not its bottom. `to_collision_dict` was the only thing in the pipeline that disagreed, and it inflated every exported collision box upward by `size.y/2`.

## Evidence

Settled by live measurement in the consuming game (frogmog), not by reading code. Player teleported above three columns and allowed to settle, against two predictions computed from the committed export beforehand:

| probe | centered predicts | bottom-anchored predicts | measured |
|---|---|---|---|
| mesa centre | **14.10** | 15.25 | **14.100** |
| base ring | **10.50** | 10.75 | 10.540 |
| spawn | **11.10** | 11.30 | **11.100** |

Consistent with the renderer (`block_builder.gd` places centered Godot primitives at `collision_offset`), with `studio_ghost.gd`'s `_grid_pos.y = _block_size.y * 0.5` compensation, and with the player's own `CharacterBody3D` floor.

## Change

`height = position + offset + size.y` → `+ size.y/2`, across every shape branch. Torus/arch likewise `+ ring_r*2` → `+ ring_r`.

## What this fixed downstream

In frogmog the bottom-anchored export meant the authoritative server believed players standing on rendered decks were metres inside solid rock, so its line-of-sight refused **84% of legitimate shots**. With this corrected, the offline sweep reports 0.0% bogus blocks across 98k sightlines and a live match measured 0 bogus rejections in 60 records. Bot nav spawn heights now match the live player to the centimetre.

## Rejected alternative

An earlier attempt moved the **renderer** to bottom-anchored instead (dead branch `gc-56/bottom-anchor-primitives`). Measured live, that was the wrong side — it shifted every rendered block up half a height and broke hand-placed content across every map. Content is authored against the rendering, so the rendering is the fixed point; a vote-count of code sites is not.

## Tests

`run_tests.gd` 340/340 · `run_power_grid_tests.gd` 394/394.

## Note for consumers

Anything caching built output must be regenerated — in frogmog the compiled world cache bakes node positions into PackedScenes and had to be deleted, not just recompiled.

Tracked as TJ-Dev-Studio/frogmog#610.